### PR TITLE
chore: bump project and parent versions to 15.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<artifactId>fess-ds-box</artifactId>
 	<packaging>jar</packaging>
 	<name>Box Data Store</name>
-	<version>15.2.1-SNAPSHOT</version>
+	<version>15.3.0-SNAPSHOT</version>
 	<scm>
 		<connection>scm:git:git@github.com:codelibs/fess-ds-box.git</connection>
 		<developerConnection>scm:git:git@github.com:codelibs/fess-ds-box.git</developerConnection>
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.codelibs.fess</groupId>
 		<artifactId>fess-parent</artifactId>
-		<version>15.2.0</version>
+		<version>15.3.0</version>
 		<relativePath />
 	</parent>
 	<properties>


### PR DESCRIPTION
## Summary
This PR updates the project version to prepare for the 15.3.0 release cycle. I've bumped both the project version and the parent dependency version to maintain compatibility with the latest fess-parent release.

## Changes Made
- Updated project version from `15.2.1-SNAPSHOT` to `15.3.0-SNAPSHOT` in pom.xml:7
- Updated fess-parent version from `15.2.0` to `15.3.0` in pom.xml:17

## Testing
- Build verification: `mvn clean package`
- Dependency resolution check
- No functional changes - version bump only

## Additional Notes
This version bump follows the project's release cycle pattern, preparing the codebase for the next development iteration aligned with the fess-parent 15.3.0 release.