### PR TITLE
chore: bump project and parent versions to 15.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<artifactId>fess-ds-box</artifactId>
 	<packaging>jar</packaging>
 	<name>Box Data Store</name>
-	<version>15.3.1-SNAPSHOT</version>
+	<version>15.4.0-SNAPSHOT</version>
 	<scm>
 		<connection>scm:git:git@github.com:codelibs/fess-ds-box.git</connection>
 		<developerConnection>scm:git:git@github.com:codelibs/fess-ds-box.git</developerConnection>
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.codelibs.fess</groupId>
 		<artifactId>fess-parent</artifactId>
-		<version>15.3.0</version>
+		<version>15.4.0</version>
 		<relativePath />
 	</parent>
 	<properties>


### PR DESCRIPTION
## Summary

Update project and parent POM versions to prepare for the 15.4.0 release cycle.

## Changes Made

- Update project version from `15.3.1-SNAPSHOT` to `15.4.0-SNAPSHOT`
- Update parent `fess-parent` version from `15.3.0` to `15.4.0`

## Testing

- Build verification: Run `mvn clean package` to verify the project builds successfully with the new parent version

## Additional Notes

This is a routine version bump to align with the Fess 15.4.0 release cycle.