### PR TITLE
Update version to 15.7.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<artifactId>fess-ds-box</artifactId>
 	<packaging>jar</packaging>
 	<name>Box Data Store</name>
-	<version>15.6.1-SNAPSHOT</version>
+	<version>15.7.0-SNAPSHOT</version>
 	<scm>
 		<connection>scm:git:git@github.com:codelibs/fess-ds-box.git</connection>
 		<developerConnection>scm:git:git@github.com:codelibs/fess-ds-box.git</developerConnection>
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.codelibs.fess</groupId>
 		<artifactId>fess-parent</artifactId>
-		<version>15.6.0</version>
+		<version>15.7.0-SNAPSHOT</version>
 		<relativePath />
 	</parent>
 	<properties>


### PR DESCRIPTION
## Summary

Bump version for the 15.7.0 development cycle. Depends on `fess-parent` `15.7.0-SNAPSHOT` which is already available on the Maven snapshot repository.

- Project version: `15.6.x-SNAPSHOT` -> `15.7.0-SNAPSHOT`
- `fess-parent` reference: `15.6.0` -> `15.7.0-SNAPSHOT`

## Test plan

- [ ] CI build passes against `fess-parent:15.7.0-SNAPSHOT`